### PR TITLE
add redux-persist

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
+    "redux-persist": "^6.0.0",
     "typescript": "*",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
+import { PersistGate } from 'redux-persist/integration/react'
+
 import App from './App'
+import { persistor, persistedStore } from './store'
+
 import './index.css'
-import { store } from './store'
 import 'bootstrap/dist/css/bootstrap.min.css'
 
 const root = ReactDOM.createRoot(
@@ -11,8 +14,10 @@ const root = ReactDOM.createRoot(
 )
 root.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <App />
+    <Provider store={persistedStore}>
+      <PersistGate loading={null} persistor={persistor}>
+       <App />
+      </PersistGate>
     </Provider>
   </React.StrictMode>
 )

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
-import session from 'redux-persist/lib/storage/session'
+import storageSession from 'redux-persist/lib/storage/session'
 import {
   persistStore,
   persistReducer,
@@ -18,6 +18,10 @@ import borrowReducer from './slices/borrow/borrow'
 import userReducer, { userActions } from './slices/user/user'
 import roomReducer from './slices/room/room'
 
+/*
+ * Token expiration handling logic
+ */
+
 axios.interceptors.response.use(
   response => response,
   async (error) => {
@@ -31,7 +35,7 @@ axios.interceptors.response.use(
 )
 
 /*
- * Non-persisted Store (only for testing)
+ * Non-persisted Store (only for testing / typescript typing)
  */
 
 export const store = configureStore({
@@ -62,7 +66,7 @@ const reducers = combineReducers({
 
 const persistConfig = {
   key: 'root',
-  storage: session
+  storage: storageSession
 }
 
 const persistedReducer = persistReducer(persistConfig, reducers)

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,5 +1,16 @@
 import axios from 'axios'
-import { configureStore } from '@reduxjs/toolkit'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import session from 'redux-persist/lib/storage/session'
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER
+} from 'redux-persist'
 
 import bookReducer from './slices/book/book'
 import lendReducer from './slices/lend/lend'
@@ -11,12 +22,17 @@ axios.interceptors.response.use(
   response => response,
   async (error) => {
     if (error.response.status === 401) {
-      store.dispatch(userActions.logout())
+      axios.defaults.headers.common.Authorization = ''
+      persistedStore.dispatch(userActions.logout())
       alert('Token has been expired')
     }
     throw error
   }
 )
+
+/*
+ * Non-persisted Store (only for testing)
+ */
 
 export const store = configureStore({
   reducer: {
@@ -31,3 +47,33 @@ export const store = configureStore({
 export type RootState = ReturnType<typeof store.getState>
 export type AppStore = typeof store
 export type AppDispatch = typeof store.dispatch
+
+/*
+ * Persisted Store (actually used)
+ */
+
+const reducers = combineReducers({
+  book: bookReducer,
+  lend: lendReducer,
+  borrow: borrowReducer,
+  user: userReducer,
+  room: roomReducer
+})
+
+const persistConfig = {
+  key: 'root',
+  storage: session
+}
+
+const persistedReducer = persistReducer(persistConfig, reducers)
+
+export const persistedStore = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware({
+    serializableCheck: {
+      ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]
+    }
+  })
+})
+
+export const persistor = persistStore(persistedStore)

--- a/frontend/src/store/slices/user/user.ts
+++ b/frontend/src/store/slices/user/user.ts
@@ -78,6 +78,7 @@ export const requestLogout = createAsyncThunk(
   'user/requestLogout',
   async (data: never, { dispatch }) => {
     const response = await axios.put('/api/user/logout/')
+    axios.defaults.headers.common.Authorization = ''
     dispatch(userActions.logout())
     return response.data
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7877,6 +7877,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"


### PR DESCRIPTION
1. redux-persist 추가
- 이제 F5를 눌러도 Redux 상태가 사라지지 않음
- session storage를 사용하여 브라우저의 다른 탭으로 접속하면 로그인 상태가 공유되지 않게 함
- package.json에 redux-persist가 추가되었으므로 pull 받고 새로 yarn 명령을 실행해야 함

2. 많이 사용해 보고 버그 리포트 대환영. 발견된 버그가 고치기 매우 힘든 경우 redux-persist를 적용하지 않을 예정